### PR TITLE
Minor pattern validation fix

### DIFF
--- a/segvan.cpp
+++ b/segvan.cpp
@@ -170,7 +170,7 @@ int main (int argc, char** argv)
     }
 
     if (ignore_case) {
-        // Now that we're passed the pattern checks, lowercase everything again
+        // Now that we're past the pattern checks, lowercase everything again
         boost::algorithm::to_lower(pattern);
     }
 

--- a/segvan.cpp
+++ b/segvan.cpp
@@ -152,6 +152,9 @@ int main (int argc, char** argv)
     pattern = argv[optind];
     if (ignore_case) {
         boost::algorithm::to_lower(pattern);
+
+        // lowercase 'l' not a valid char; will fail regex test
+        boost::algorithm::replace_all(pattern, "l", "L");
     }
 
     if (std::regex_match(pattern, mainnet_p2sh_pattern)) {
@@ -165,6 +168,12 @@ int main (int argc, char** argv)
         usage();
         abort();
     }
+
+    if (ignore_case) {
+        // Now that we're passed the pattern checks, lowercase everything again
+        boost::algorithm::to_lower(pattern);
+    }
+
 
     if (debug_output) {
         std::cout << "Searching for address beginning with " << pattern;


### PR DESCRIPTION
`ignore_case` pattern validation fails if there's an "L".